### PR TITLE
Added `query` to the keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Changseok Han <freestrings@gmail.com>"]
 description = "It is JsonPath engine written in Rust. it provide a similar API interface in Webassembly and Javascript too. - Webassembly Demo: https://freestrings.github.io/jsonpath"
 readme = "README.md"
 
-keywords = ["jsonpath", "json", "webassembly", "nodejs", "javascript", "query"]
+keywords = ["jsonpath", "json", "webassembly", "nodejs", "query"]
 
 repository = "https://github.com/freestrings/jsonpath"
 documentation = "https://docs.rs/jsonpath_lib/0.1.0/jsonpath_lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Changseok Han <freestrings@gmail.com>"]
 description = "It is JsonPath engine written in Rust. it provide a similar API interface in Webassembly and Javascript too. - Webassembly Demo: https://freestrings.github.io/jsonpath"
 readme = "README.md"
 
-keywords = ["jsonpath", "json", "webassembly", "nodejs", "javascript"]
+keywords = ["jsonpath", "json", "webassembly", "nodejs", "javascript", "query"]
 
 repository = "https://github.com/freestrings/jsonpath"
 documentation = "https://docs.rs/jsonpath_lib/0.1.0/jsonpath_lib"


### PR DESCRIPTION
I added `query` to the keywords to help people find this on crates.io as there are a few similar crates that use `json` and `query`.