### PR TITLE
Replace fun input with ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ let result = selector_mut
             0
         };
 
-        json!(age)
+        Some(json!(age))
     }).unwrap()
     .take().unwrap();
 
@@ -353,7 +353,7 @@ let ret = jsonpath::replace_with(json_obj, "$..[?(@.age == 20)].age", &mut |v| {
         0
     };
 
-    json!(age)
+    Some(json!(age))
 }).unwrap();
 
 assert_eq!(ret, json!({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,7 +443,7 @@ pub fn delete(value: Value, path: &str) -> Result<Value, JsonPathError> {
 ///         0
 ///     };
 ///
-///     json!(age)
+///     Some(json!(age))
 /// }).unwrap();
 ///
 /// assert_eq!(ret, json!({
@@ -460,7 +460,7 @@ pub fn delete(value: Value, path: &str) -> Result<Value, JsonPathError> {
 /// ```
 pub fn replace_with<F>(value: Value, path: &str, fun: &mut F) -> Result<Value, JsonPathError>
 where
-    F: FnMut(Value) -> Value,
+    F: FnMut(Value) -> Option<Value>,
 {
     let mut selector = SelectorMut::default();
     let value = selector.str_path(path)?.value(value).replace_with(fun)?;

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -224,7 +224,7 @@ fn readme_selector_mut() {
                 0
             };
 
-            json!(age)
+            Some(json!(age))
         })
         .unwrap()
         .take()
@@ -522,7 +522,7 @@ fn readme_replace_with() {
             0
         };
 
-        json!(age)
+        Some(json!(age))
     })
     .unwrap();
 

--- a/tests/selector.rs
+++ b/tests/selector.rs
@@ -23,7 +23,7 @@ fn selector_mut() {
             if let Value::Number(n) = v {
                 nums.push(n.as_f64().unwrap());
             }
-            Value::String("a".to_string())
+            Some(Value::String("a".to_string()))
         })
         .unwrap()
         .take()
@@ -96,3 +96,37 @@ fn selector_delete() {
         ]
     );
 }
+
+#[test]
+fn selector_remove() {
+    setup();
+
+    let mut selector_mut = SelectorMut::default();
+
+    let result = selector_mut
+        .str_path(r#"$.store..price[?(@>13)]"#)
+        .unwrap()
+        .value(read_json("./benchmark/example.json"))
+        .remove()
+        .unwrap()
+        .take()
+        .unwrap();
+
+    let mut selector = Selector::default();
+    let result = selector
+        .str_path(r#"$.store..price"#)
+        .unwrap()
+        .value(&result)
+        .select()
+        .unwrap();
+
+    assert_eq!(
+        result,
+        vec![
+            &json!(8.95),
+            &json!(12.99),
+            &json!(8.99)
+        ]
+    );
+}
+

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -56,24 +56,24 @@ where
     }
 }
 
-fn replace_fun(v: Value, fun: &js_sys::Function) -> Value {
+fn replace_fun(v: Value, fun: &js_sys::Function) -> Option<Value> {
     match JsValue::from_serde(&v) {
         Ok(js_v) => match fun.call1(&JsValue::NULL, &js_v) {
             Ok(result) => match into_serde_json(&result) {
-                Ok(json) => json,
+                Ok(json) => Some(json),
                 Err(e) => {
                     console_error!("replace_with - closure returned a invalid JSON: {:?}", e);
-                    Value::Null
+                    Some(Value::Null)
                 }
             },
             Err(e) => {
                 console_error!("replace_with - fail to call closure: {:?}", e);
-                Value::Null
+                Some(Value::Null)
             }
         },
         Err(e) => {
             console_error!("replace_with - invalid JSON object: {:?}", e);
-            Value::Null
+            Some(Value::Null)
         }
     }
 }


### PR DESCRIPTION
When a value is passed by value and not reference the user can return the original value and avoid clone()