### PR TITLE
Make JsonPathError implement std::error::Error 

### DIFF
--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -44,6 +44,8 @@ pub enum JsonPathError {
     Serde(String),
 }
 
+impl std::error::Error for JsonPathError {}
+
 impl fmt::Debug for JsonPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self)


### PR DESCRIPTION
Make JsonPathError implement std::error::Error so it can be encapsulated as a valid source by libraries or programs that implement their own error type.
Specifically this is usefull when using [thiserror](https://github.com/dtolnay/thiserror), for example now we can have the following error type in our program that uses jsonpath:
```rust
use thiserror::Error;

#[derive(Error, Debug)]
pub enum MyError {
    #[error("General error: {0}")]
    GeneralError(String),

    #[error("JSON path error {0}")]
    InvalidJsonPath(#[from] jsonpath_lib::JsonPathError),

    #[error("Some other error")]
    SomeOtherError,
}
```