### PR TITLE
Make the parser public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub use select::{Selector, SelectorMut};
 #[doc(hidden)]
 mod ffi;
 #[doc(hidden)]
-mod parser;
+pub mod parser;
 #[doc(hidden)]
 mod select;
 


### PR DESCRIPTION
Fixes #61 by allowing custom implementations of the `compile` function, which would require the `Node` and `ParserResult` types.