### PR TITLE
Move env-logger to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ travis-ci = { repository = "freestrings/jsonpath", branch = "master" }
 
 [dependencies]
 log = "0.4"
-env_logger = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 array_tool = "1.0.3"
+
+[dev-dependencies]
+env_logger = "0.8"
 
 [lib]
 name = "jsonpath_lib"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,6 @@
 //! ```
 extern crate array_tool;
 extern crate core;
-extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate serde;


### PR DESCRIPTION
Just noticed this dependency cropped up in my application through `cargo tree -d`.

Since (as far as I understand) this is just a library and all references of `env-logger` I found are in tests, it should be moved to `[dev-dependencies]`.

On my local both `cargo build` and `cargo test` succeed (with rustc 1.50).