### PR TITLE
Fix crash on removing multiple elements from an array

### DIFF
--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -811,11 +811,13 @@ fn replace_value<F: FnMut(Value) -> Option<Value>>(
             Value::Array(ref mut vec) => {
                 if let Ok(x) = token.parse::<usize>() {
                     if is_last {
-                        let v = std::mem::replace(&mut vec[x], Value::Null);
-                        if let Some(res) = fun(v) {
-                            vec[x] = res;
-                        } else {
-                            vec.remove(x);
+                        if x < vec.len() {
+                            let v = std::mem::replace(&mut vec[x], Value::Null);
+                            if let Some(res) = fun(v) {
+                                vec[x] = res;
+                            } else {
+                                vec.remove(x);
+                            }
                         }
                         return;
                     }

--- a/tests/selector.rs
+++ b/tests/selector.rs
@@ -63,6 +63,27 @@ fn selector_node_ref() {
 }
 
 #[test]
+fn selector_delete_multi_elements_from_array() {
+    setup();
+
+    let mut selector_mut = SelectorMut::default();
+
+    let result = selector_mut
+        .str_path(r#"$[0,2]"#)
+        .unwrap()
+        .value(serde_json::from_str("[1,2,3]").unwrap())
+        .remove()
+        .unwrap()
+        .take()
+        .unwrap();
+
+    assert_eq!(
+        result,
+        serde_json::from_str::<serde_json::Value>("[2,3]").unwrap(),
+    );
+}
+
+#[test]
 fn selector_delete() {
     setup();
 


### PR DESCRIPTION
If the first element we remove causes the second element path to be invalid, the code will try to access an invalid index of the array.