### PR TITLE
Changed parser::Node back to public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ extern crate serde_json;
 use serde_json::Value;
 
 #[allow(deprecated)]
-use parser::Node;
+pub use parser::Node;
 #[allow(deprecated)]
 pub use parser::Parser;
 #[allow(deprecated)]


### PR DESCRIPTION
We've been locked on 0.2.3 since `Parser` and `Node` were made private. https://github.com/freestrings/jsonpath/issues/36

https://github.com/freestrings/jsonpath/pull/26 changed Parser back public for our use, but we're still blocked on `Node`. This would let us upgrade to the next version of jsonpath.